### PR TITLE
Bump version 1.02 -> 1.1.0

### DIFF
--- a/Casks/whereami.rb
+++ b/Casks/whereami.rb
@@ -1,8 +1,8 @@
 cask 'whereami' do
   version :latest
-  sha256 '6cc9ecaba9e1e9f5618cd239dc8eb6bac0bd86e06c29297c8fda900f26b2b829'
+  sha256 '68041a9308d92877d984e7a01fb68035b83ae48166b6548a19fc55474b3685b0'
 
-  url 'https://github.com/robmathers/WhereAmI/releases/download/v1.02/whereami-1.02.zip'
+  url 'https://github.com/robmathers/WhereAmI/releases/download/v1.1.0/whereami-1.1.0.zip'
   name 'whereami'
   homepage 'https://github.com/robmathers/WhereAmI'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
Adds support for the OpenCage geocoding API: https://github.com/robmathers/WhereAmI#110